### PR TITLE
Switch to JSON5 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,3 @@ Use by extending in your `renovate.json`:
   ]
 }
 ```
-
-## Disabled Config Blocks
-
-Since [Shareable Config Presets don't support JSON5](https://github.com/renovatebot/renovate/issues/7674) or [JavaScript](https://github.com/renovatebot/renovate/issues/14517), it's not possible to temporarily disable parts of the config within the file.
-
-The configuration blocks below are these blocks that should be currently disabled:
-
-### Automerge GitHub Official Actions
-
-Since these actions don't get major version bumps often, manually merging is probably still acceptable:
-
-```json
-    {
-      "groupName": "GitHub Official Actions - major",
-      "depTypeList": ["action"],
-      "updateTypes": ["major"],
-      "matchPackageNames": ["actions/checkout", "actions/setup-node", "actions/upload-artifact"],
-      "automerge": true
-    },
-```

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Use by extending in your `renovate.json`:
 
 ```json
 {
-  "extends": [
-    "github>karlhorky/renovate-config"
-  ]
+  "extends": ["github>karlhorky/renovate-config:default.json5"]
 }
 ```

--- a/default.json
+++ b/default.json
@@ -1,39 +1,48 @@
 {
-  "extends": ["config:base"],
-  "ignorePresets": [":prHourlyLimit2"],
-  "packageRules": [
+  extends: ['config:base'],
+  ignorePresets: [':prHourlyLimit2'],
+  packageRules: [
     {
-      "groupName": "dependency upgrades - non-major",
-      "depTypeList": [
-        "devDependencies",
-        "dependencies",
-        "peerDependencies",
-        "resolutions"
+      groupName: 'dependency upgrades - non-major',
+      depTypeList: [
+        'devDependencies',
+        'dependencies',
+        'peerDependencies',
+        'resolutions',
       ],
-      "updateTypes": ["patch", "minor"],
-      "automerge": true
+      updateTypes: ['patch', 'minor'],
+      automerge: true,
     },
     {
-      "groupName": "eslint devDependencies - major",
-      "depTypeList": [
-        "devDependencies",
-        "dependencies",
-        "peerDependencies",
-        "resolutions"
+      groupName: 'eslint devDependencies - major',
+      depTypeList: [
+        'devDependencies',
+        'dependencies',
+        'peerDependencies',
+        'resolutions',
       ],
-      "updateTypes": ["major"],
-      "matchPackageNames": ["eslint-plugin-unicorn"],
-      "automerge": true
+      updateTypes: ['major'],
+      matchPackageNames: ['eslint-plugin-unicorn'],
+      automerge: true,
     },
     {
-      "description": "Enable major version upgrades of @types/node https://github.com/renovatebot/renovate/issues/1463#issuecomment-875014401",
-      "matchManagers": ["npm"],
-      "matchPackageNames": ["@types/node"],
-      "versioning": "npm"
-    }
+      description:
+        'Enable major version upgrades of @types/node https://github.com/renovatebot/renovate/issues/1463#issuecomment-875014401',
+      matchManagers: ['npm'],
+      matchPackageNames: ['@types/node'],
+      versioning: 'npm',
+    },
+    // Disabled since these GitHub Actions don't get major version bumps often
+    // {
+    //   "groupName": "GitHub Official Actions - major",
+    //   "depTypeList": ["action"],
+    //   "updateTypes": ["major"],
+    //   "matchPackageNames": ["actions/checkout", "actions/setup-node", "actions/upload-artifact"],
+    //   "automerge": true
+    // },
   ],
-  "schedule": "after 4pm on thursday",
-  "vulnerabilityAlerts": {
-    "schedule": null
-  }
+  schedule: 'after 4pm on thursday',
+  vulnerabilityAlerts: {
+    schedule: null,
+  },
 }

--- a/default.json5
+++ b/default.json5
@@ -26,8 +26,7 @@
       automerge: true,
     },
     {
-      description:
-        'Enable major version upgrades of @types/node https://github.com/renovatebot/renovate/issues/1463#issuecomment-875014401',
+      description: 'Enable major version upgrades of @types/node https://github.com/renovatebot/renovate/issues/1463#issuecomment-875014401',
       matchManagers: ['npm'],
       matchPackageNames: ['@types/node'],
       versioning: 'npm',


### PR DESCRIPTION
TODO:

- [x] Wait for the GitHub Actions Renovate bot to be upgraded to `32.35.0` (currently on `32.34.0`)
- [x] If https://github.com/renovatebot/renovate/issues/15370 gets implemented and configs can use `.json5` or other file extensions, then also rename the `default.json` file to `default.json5`